### PR TITLE
Fix: Expert Learning Session

### DIFF
--- a/components/territorio/why-learn-with-expert/TS-WhyLearnWithExpert.tsx
+++ b/components/territorio/why-learn-with-expert/TS-WhyLearnWithExpert.tsx
@@ -5,6 +5,8 @@ import TsActionButton, {
   CTAButton,
 } from "../action-button/Ts-Action-Button.tsx";
 import TsTypography from "../typography/TS-Typography.tsx";
+import { AppContext } from "../../../apps/site.ts";
+import useTsIsMobile from "deco-sites/territorio/hooks/useTsIsMobile.tsx";
 
 /** @title Statistic: {{value}} */
 export interface StatisticProps {
@@ -28,7 +30,7 @@ export interface Paragraph {
   content: string;
 }
 
-export interface Props {
+export interface WhyProps {
   title: {
     primary: string;
     secondary: string;
@@ -44,7 +46,7 @@ export interface Props {
   ctaButton: CTAButton;
 }
 
-export default function TsWhyLearnWithExpert({
+const TsWhyLearnWithExpert = ({
   ctaButton,
   title: { primary, secondary },
   statistics,
@@ -52,7 +54,9 @@ export default function TsWhyLearnWithExpert({
   expertName,
   additionalInfo,
   img,
-}: Props) {
+}: WhyProps) => {
+  const isMobile = useTsIsMobile();
+
   const ExpertMainInfo = (
     <div class="flex flex-col gap-5">
       <TsTypography
@@ -96,8 +100,12 @@ export default function TsWhyLearnWithExpert({
           <div class="col-span-2 row-span-2 row-start-3 sm:row-start-1 sm:col-start-2">
             <Image {...img} class="w-full" />
           </div>
-          <Statistic {...statistics[1]} />
-          <Statistic {...statistics[2]} />
+          {isMobile
+            ? <Statistic {...statistics[2]} />
+            : <Statistic {...statistics[1]} />}
+          {isMobile
+            ? <Statistic {...statistics[1]} />
+            : <Statistic {...statistics[2]} />}
           <Statistic {...statistics[3]} />
         </div>
 
@@ -137,4 +145,10 @@ export default function TsWhyLearnWithExpert({
       </TsActionButton>
     </div>
   );
-}
+};
+
+export const loader = (props: WhyProps, _req: Request, ctx: AppContext) => {
+  return { ...props, device: ctx.device };
+};
+
+export default TsWhyLearnWithExpert;

--- a/components/territorio/why-learn-with-expert/TS-WhyLearnWithExpert.tsx
+++ b/components/territorio/why-learn-with-expert/TS-WhyLearnWithExpert.tsx
@@ -95,7 +95,7 @@ const TsWhyLearnWithExpert = ({
       </TsTypography>
 
       <div class="flex flex-col gap-[1.875rem] sm:gap-16">
-        <div class="grid grid-cols-2 sm:grid-cols-4 grid-flow-row gap-y-8 sm:gap-y-20 gap-x-4 sm:gap-x-0">
+        <div class="grid grid-cols-2 sm:grid-cols-4 grid-flow-row gap-y-8 gap-x-4 sm:gap-x-0">
           <Statistic {...statistics[0]} />
           <div class="col-span-2 row-span-2 row-start-3 sm:row-start-1 sm:col-start-2">
             <Image {...img} class="w-full" />

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -37,6 +37,7 @@ import * as $territorio_TS_HeaderButton from "./islands/territorio/TS-HeaderButt
 import * as $territorio_TS_Hero from "./islands/territorio/TS-Hero.tsx";
 import * as $territorio_TS_Newsletter from "./islands/territorio/TS-Newsletter.tsx";
 import * as $territorio_TS_TestimonialsCarouselDesk from "./islands/territorio/TS-TestimonialsCarouselDesk.tsx";
+import * as $territorio_TS_WhyLearnWithExpert from "./islands/territorio/TS-WhyLearnWithExpert.tsx";
 import { type Manifest } from "$fresh/server.ts";
 
 const manifest = {
@@ -79,6 +80,8 @@ const manifest = {
     "./islands/territorio/TS-Newsletter.tsx": $territorio_TS_Newsletter,
     "./islands/territorio/TS-TestimonialsCarouselDesk.tsx":
       $territorio_TS_TestimonialsCarouselDesk,
+    "./islands/territorio/TS-WhyLearnWithExpert.tsx":
+      $territorio_TS_WhyLearnWithExpert,
   },
   baseUrl: import.meta.url,
 } satisfies Manifest;

--- a/hooks/useTsIsMobile.tsx
+++ b/hooks/useTsIsMobile.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "preact/compat";
+import useTsDimensions from "deco-sites/territorio/hooks/useTsDimensions.tsx";
+
+export default function useTsIsMobile() {
+  const { width } = useTsDimensions();
+  const [isMobile, setIsMobile] = useState(width < 640);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(width < 640);
+    };
+
+    if (window) {
+      globalThis.addEventListener("resize", handleResize);
+      return () => globalThis.removeEventListener("resize", handleResize);
+    }
+  }, []);
+
+  return isMobile;
+}

--- a/islands/territorio/TS-WhyLearnWithExpert.tsx
+++ b/islands/territorio/TS-WhyLearnWithExpert.tsx
@@ -1,0 +1,8 @@
+import type { WhyProps } from "../../components/territorio/why-learn-with-expert/TS-WhyLearnWithExpert.tsx";
+import Component from "../../components/territorio/why-learn-with-expert/TS-WhyLearnWithExpert.tsx";
+
+function Island(props: WhyProps) {
+  return <Component {...props} />;
+}
+
+export default Island;

--- a/sections/territorio/TS-WhyLearnWithExpert.tsx
+++ b/sections/territorio/TS-WhyLearnWithExpert.tsx
@@ -1,1 +1,2 @@
-export { default } from "../../components/territorio/why-learn-with-expert/TS-WhyLearnWithExpert.tsx";
+export { loader } from "../../components/territorio/why-learn-with-expert/TS-WhyLearnWithExpert.tsx";
+export { default } from "../../islands/territorio/TS-WhyLearnWithExpert.tsx";


### PR DESCRIPTION
A ordem das informações está trocada, 10 milhões de cópias fica na primeira linha.
O espaçamento entre linhas parece maior, o que deixa a sessão muito mais “comprida”.

Mobile:
<img width="364" alt="Screenshot 2024-05-22 at 19 29 09" src="https://github.com/deco-sites/territorio/assets/11914514/b91e45d3-fdbc-4e64-ac50-bfcc6c949bce">

Desktop:
<img width="881" alt="Screenshot 2024-05-22 at 19 30 46" src="https://github.com/deco-sites/territorio/assets/11914514/bbb0a54b-e659-4a0a-9a15-e9b300212642">
