### PR TITLE
Fix: Collapse Icon on Expert details was inverted

### DIFF
--- a/components/territorio/why-learn-with-expert/TS-WhyLearnWithExpert.tsx
+++ b/components/territorio/why-learn-with-expert/TS-WhyLearnWithExpert.tsx
@@ -122,8 +122,8 @@ const TsWhyLearnWithExpert = ({
             defaultCheckedFirst={false}
             name="expert-info"
             icon={{
-              collapse: "Less",
-              expand: "More",
+              collapse: "More",
+              expand: "Less",
             }}
             iconPosition="bottom"
           >


### PR DESCRIPTION
Images after the changes:

![image](https://github.com/deco-sites/territorio/assets/16403023/6157f8d9-bbba-4c6d-9a97-f84034df83aa)
![image](https://github.com/deco-sites/territorio/assets/16403023/f78682db-894e-4444-814c-18c43c5b7e68)


[CKLSM-219](https://cheesecakelabs.atlassian.net/jira/servicedesk/projects/CKLSM/issues/CKLSM-219?jql=project%20%3D%20%22CKLSM%22%20ORDER%20BY%20created%20DESC)